### PR TITLE
Update react-tools version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/joakimbeng/react-swiper",
   "devDependencies": {
-    "react-tools": "~0.11.2"
+    "react-tools": "~0.13.2"
   },
   "dependencies": {
     "object-assign": "^2.0.0"


### PR DESCRIPTION
Doesn't compile in React 0.13
